### PR TITLE
NGFW-15475: Grub installation error on Protecli Vault

### DIFF
--- a/profiles/auto-partition.preseed
+++ b/profiles/auto-partition.preseed
@@ -80,9 +80,13 @@ format{ } \
 
 d-i partman-auto/expert_recipe string \
 untangle-efi :: \
-500 10000 1000000 ext4 \
+512 512 512 fat32 \
 $primary{ } \
-$bootable{ } \
+method{ efi } \
+format{ } \
+mountpoint{ /boot/efi } \
+. \
+500 10000 1000000 ext4 \
 method{ format } \
 format{ } \
 use_filesystem{ } \
@@ -93,36 +97,31 @@ label{ NGFW_ROOT } \
 1000 2000 300% swap \
 method{ swap } \
 format{ } \
-. \
-512 512 512 fat32 \
-$primary{ } \
-method{ efi } \
-format{ } \
 .
 
 d-i partman/early_command string \
-mounts=$(mount | grep cdrom) \
-count=0; \
-selected_disk=""; \
-candidate=""; \
-for device in $(parted_devices | cut -f1); do \
-  count=$(($count + 1)); \
-  echo $mounts | grep -q $device; \
-  if [ $? -eq 0 ] ; then \
-    continue; \
-  fi ; \
-  candidate=$device ; \
-done ; \
-if [ $count -eq 2 ] ; then \
-   debconf-set partman-auto/disk $candidate ; \
-fi ; \
-if list-devices disk | grep -q '^/dev/mmcblk0$'; then \
-   if [ -n "$(list-devices partition | grep '^/dev/mmcblk0p[0-9]')" ]; then \
-      debconf-set partman-auto/disk string /dev/mmcblk0 ; \
-   fi; \
+cdrom_dev=$(mount | grep "/cdrom" | awk '{print $1}' | sed 's/p[0-9]*$//'); \
+for dev in $(list-devices disk); do \
+    if [ "$dev" = "$cdrom_dev" ]; then \
+        continue; \
+    fi; \
+    if echo "$dev" | grep -q "nvme"; then \
+        nvme_dev=$dev; \
+    elif echo "$dev" | grep -q "mmc"; then \
+        mmc_dev=$dev; \
+    fi; \
+done; \
+if [ -n "$nvme_dev" ]; then \
+    debconf-set partman-auto/disk $nvme_dev; \
+    debconf-set grub-installer/bootdev $nvme_dev; \
+elif [ -n "$mmc_dev" ]; then \
+    debconf-set partman-auto/disk $mmc_dev; \
+    debconf-set grub-installer/bootdev $mmc_dev; \
 fi; \
 if [ -d "/sys/firmware/efi/" ] ; then \
 	debconf-set partman-auto/choose_recipe select untangle-efi ; \
 else \
 	debconf-set partman-auto/choose_recipe select untangle2 ; \
-fi ;
+fi;
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean false


### PR DESCRIPTION
The root cause of the GRUB installation failure is a combination of three issues in the profiles/auto-partition.preseed file:

Ambiguous Disk Selection: The installer could still potentially select the wrong disk under certain conditions. Support for nvme drive is not present

Unmounted EFI Partition: The untangle-efi recipe in auto-partition.preseed defines an EFI partition but does not mount it. This is a crucial omission. When the installer sees an existing EFI partition on the eMMC, it reuses it, leading to the GRUB installation on the wrong device, even if the root filesystem is on the NVMe.

Incomplete Recipe: The untangle-efi recipe was also not correctly structured. The EFI partition should be defined after the root and swap partitions.



Fix contains following changes
1. Check for an NVMe drive (/dev/nvme0n1). If it exists, use it for both partitioning and GRUB installation.
2. If no NVMe drive is found, check for an eMMC drive (/dev/mmcblk0) and use that.
As a fallback, if neither is found, it will use the existing logic to select a disk, which will work for the older hardware.
3. Corrected the untangle-efi recipe:  modfified the untangle-efi recipe to correctly mount the EFI partition at /boot/efi and ensure the partitions are in the correct order.